### PR TITLE
Add preload option for default categories

### DIFF
--- a/YoddWatchLibrary/TMDBClient.swift
+++ b/YoddWatchLibrary/TMDBClient.swift
@@ -300,5 +300,16 @@ public class TMDBClient {
             }
         ]
     }
+
+    /// Returns default categories and optionally preloads the first page of each one.
+    public func defaultMovieCategories(region: String = "US", language: String = "en", preload: Bool) async throws -> [MovieCategory] {
+        let categories = defaultMovieCategories(region: region, language: language)
+        if preload {
+            for category in categories {
+                try await category.reload()
+            }
+        }
+        return categories
+    }
 }
 

--- a/YoddWatchLibraryTests/YoddWatchLibraryTests.swift
+++ b/YoddWatchLibraryTests/YoddWatchLibraryTests.swift
@@ -27,4 +27,19 @@ struct YoddWatchLibraryTests {
         prefs.setProgress(id: 7, minutes: 42)
         #expect(prefs.progress(for: 7) == 42)
     }
+
+    @Test func defaultMovieCategories() throws {
+        let client = TMDBClient(apiKey: "test")!
+        let categories = client.defaultMovieCategories()
+        #expect(!categories.isEmpty)
+        let names = categories.map { $0.name }
+        #expect(names.contains("Trending"))
+        #expect(names.contains("Top Rated"))
+    }
+
+    @Test func defaultMovieCategoriesPreload() async throws {
+        let client = TMDBClient(apiKey: "test")!
+        let categories = try await client.defaultMovieCategories(preload: false)
+        #expect(!categories.isEmpty)
+    }
 }


### PR DESCRIPTION
## Summary
- extend `TMDBClient.defaultMovieCategories` with a new async overload that can preload the first page
- verify categories through additional tests

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_68472c8140e88321947beb64969502f6