### PR TITLE
Implement defaultTVShowCategories

### DIFF
--- a/YoddWatchLibrary/TMDBClient.swift
+++ b/YoddWatchLibrary/TMDBClient.swift
@@ -191,6 +191,10 @@ public class TMDBClient {
             Movie(id: $0.id, title: $0.name, overview: $0.overview, posterPath: $0.posterPath, releaseDate: $0.firstAirDate, voteAverage: $0.voteAverage)
         }
     }
+
+    private func asMovies(_ shows: [TVShow]) -> [Movie] {
+        shows.map { Movie(id: $0.id, title: $0.name, overview: $0.overview, posterPath: $0.posterPath, releaseDate: $0.firstAirDate, voteAverage: $0.voteAverage) }
+    }
     
     public func movieDetails(id: Int, language: String = "en") async throws -> MovieDetails {
         async let movie: Movie = request(endpoint: "movie/\(id)", queryItems: [URLQueryItem(name: "language", value: language)], type: Movie.self)
@@ -238,6 +242,19 @@ public class TMDBClient {
             endpoint: "tv/top_rated",
             queryItems: [URLQueryItem(name: "language", value: language), URLQueryItem(name: "page", value: String(page))],
             type: SearchResponse<TVShow>.self)
+        return response.results
+    }
+
+    /// Discover TV shows available on a specific watch provider, sorted by popularity.
+    public func topTVShows(provider: WatchProvider, region: String = "US", language: String = "en", page: Int = 1) async throws -> [TVShow] {
+        let query: [URLQueryItem] = [
+            URLQueryItem(name: "language", value: language),
+            URLQueryItem(name: "with_watch_providers", value: String(provider.rawValue)),
+            URLQueryItem(name: "watch_region", value: region),
+            URLQueryItem(name: "sort_by", value: "popularity.desc"),
+            URLQueryItem(name: "page", value: String(page))
+        ]
+        let response: SearchResponse<TVShow> = try await request(endpoint: "discover/tv", queryItems: query, type: SearchResponse<TVShow>.self)
         return response.results
     }
 
@@ -304,6 +321,42 @@ public class TMDBClient {
     /// Returns default categories and optionally preloads the first page of each one.
     public func defaultMovieCategories(region: String = "US", language: String = "en", preload: Bool) async throws -> [MovieCategory] {
         let categories = defaultMovieCategories(region: region, language: language)
+        if preload {
+            for category in categories {
+                try await category.reload()
+            }
+        }
+        return categories
+    }
+
+    /// Convenience method returning a set of common TV show categories.
+    public func defaultTVShowCategories(region: String = "US", language: String = "en") -> [MovieCategory] {
+        [
+            MovieCategory(name: "Trending") { page in
+                try await self.trendingTVShows(language: language, page: page)
+            },
+            MovieCategory(name: "Top Rated") { page in
+                let shows = try await self.topRatedTVShows(language: language, page: page)
+                return self.asMovies(shows)
+            },
+            MovieCategory(name: "Popular") { page in
+                let shows = try await self.popularTVShows(language: language, page: page)
+                return self.asMovies(shows)
+            },
+            MovieCategory(name: "Top on Netflix") { page in
+                let shows = try await self.topTVShows(provider: .netflix, region: region, language: language, page: page)
+                return self.asMovies(shows)
+            },
+            MovieCategory(name: "Top on Prime Video") { page in
+                let shows = try await self.topTVShows(provider: .primeVideo, region: region, language: language, page: page)
+                return self.asMovies(shows)
+            }
+        ]
+    }
+
+    /// Returns default TV show categories and optionally preloads the first page of each one.
+    public func defaultTVShowCategories(region: String = "US", language: String = "en", preload: Bool) async throws -> [MovieCategory] {
+        let categories = defaultTVShowCategories(region: region, language: language)
         if preload {
             for category in categories {
                 try await category.reload()

--- a/YoddWatchLibrary/YoddWatchLibrary.docc/YoddWatchLibrary.md
+++ b/YoddWatchLibrary/YoddWatchLibrary.docc/YoddWatchLibrary.md
@@ -23,6 +23,7 @@ A lightweight framework providing access to The Movie Database API and basic use
 - ``Genre``
 - ``MovieCategory``
 - ``TMDBClient.defaultMovieCategories(region:language:)``
+- ``TMDBClient.defaultTVShowCategories(region:language:)``
 
 ### Preferences
 - ``UserPreferences``

--- a/YoddWatchLibraryTests/YoddWatchLibraryTests.swift
+++ b/YoddWatchLibraryTests/YoddWatchLibraryTests.swift
@@ -42,4 +42,19 @@ struct YoddWatchLibraryTests {
         let categories = try await client.defaultMovieCategories(preload: false)
         #expect(!categories.isEmpty)
     }
+
+    @Test func defaultTVShowCategories() throws {
+        let client = TMDBClient(apiKey: "test")!
+        let categories = client.defaultTVShowCategories()
+        #expect(!categories.isEmpty)
+        let names = categories.map { $0.name }
+        #expect(names.contains("Trending"))
+        #expect(names.contains("Top Rated"))
+    }
+
+    @Test func defaultTVShowCategoriesPreload() async throws {
+        let client = TMDBClient(apiKey: "test")!
+        let categories = try await client.defaultTVShowCategories(preload: false)
+        #expect(!categories.isEmpty)
+    }
 }


### PR DESCRIPTION
## Summary
- add helper to convert TVShow arrays to Movie arrays
- support fetching TV shows by watch provider
- provide defaultTVShowCategories convenience methods
- document new API and add tests

## Testing
- `swift test -l`
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68475bb684448321ae38498a9995f0e3