### PR TITLE
Add episode support for TV series

### DIFF
--- a/YoddWatchLibrary/TMDBClient.swift
+++ b/YoddWatchLibrary/TMDBClient.swift
@@ -37,6 +37,18 @@ public struct Person: Codable {
     public let profilePath: String?
 }
 
+/// A single episode of a TV show season.
+public struct Episode: Codable {
+    public let id: Int
+    public let name: String
+    public let overview: String?
+    public let stillPath: String?
+    public let seasonNumber: Int
+    public let episodeNumber: Int
+    public let airDate: String?
+    public let voteAverage: Double?
+}
+
 /// Known watch providers used by some helper methods.
 public enum WatchProvider: Int {
     case netflix = 8
@@ -210,6 +222,28 @@ public class TMDBClient {
         let s = try await show
         let credits = try await creditsResp
         return TVShowDetails(show: s, cast: credits.cast)
+    }
+
+    /// Fetches the episodes for a specific season of a TV show.
+    public func episodes(showId: Int, season: Int, language: String = "en") async throws -> [Episode] {
+        struct SeasonResponse: Codable { let episodes: [Episode] }
+        let response: SeasonResponse = try await request(
+            endpoint: "tv/\(showId)/season/\(season)",
+            queryItems: [URLQueryItem(name: "language", value: language)],
+            type: SeasonResponse.self
+        )
+        return response.episodes
+    }
+
+    /// Retrieves the number of seasons available for the given TV show.
+    public func numberOfSeasons(showId: Int, language: String = "en") async throws -> Int {
+        struct ShowInfo: Codable { let numberOfSeasons: Int }
+        let info: ShowInfo = try await request(
+            endpoint: "tv/\(showId)",
+            queryItems: [URLQueryItem(name: "language", value: language)],
+            type: ShowInfo.self
+        )
+        return info.numberOfSeasons
     }
 
     // MARK: Top/Popular

--- a/YoddWatchLibrary/YoddWatchLibrary.docc/YoddWatchLibrary.md
+++ b/YoddWatchLibrary/YoddWatchLibrary.docc/YoddWatchLibrary.md
@@ -18,6 +18,9 @@ A lightweight framework providing access to The Movie Database API and basic use
 - ``TVShow``
 - ``MovieDetails``
 - ``TVShowDetails``
+- ``Episode``
+- ``TMDBClient.episodes(showId:season:language:)``
+- ``TMDBClient.numberOfSeasons(showId:language:)``
 - ``Person``
 - ``WatchProvider``
 - ``Genre``

--- a/YoddWatchLibraryTests/YoddWatchLibraryTests.swift
+++ b/YoddWatchLibraryTests/YoddWatchLibraryTests.swift
@@ -3,6 +3,7 @@
 //  YoddWatchLibraryTests
 //
 
+import Foundation
 import Testing
 @testable import YoddWatchLibrary
 
@@ -56,5 +57,26 @@ struct YoddWatchLibraryTests {
         let client = TMDBClient(apiKey: "test")!
         let categories = try await client.defaultTVShowCategories(preload: false)
         #expect(!categories.isEmpty)
+    }
+
+    @Test func decodeEpisode() throws {
+        let json = """
+        {
+            "id": 1,
+            "name": "Pilot",
+            "overview": "Intro",
+            "still_path": "/img.jpg",
+            "season_number": 1,
+            "episode_number": 1,
+            "air_date": "2022-01-01",
+            "vote_average": 7.5
+        }
+        """.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let episode = try decoder.decode(Episode.self, from: json)
+        #expect(episode.id == 1)
+        #expect(episode.seasonNumber == 1)
+        #expect(episode.episodeNumber == 1)
     }
 }


### PR DESCRIPTION
## Summary
- introduce `Episode` model to represent TV episodes
- implement new `TMDBClient` methods for fetching episodes and season count
- document new API and add unit test for decoding `Episode`

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_684c4505bdf08321bc6a1813d34a7235