### PR TITLE
Fix duplicate build error and document genre helpers

### DIFF
--- a/YoddWatchLibrary/TMDBClient.swift
+++ b/YoddWatchLibrary/TMDBClient.swift
@@ -349,10 +349,6 @@ public class TMDBClient {
     private func asMovies(_ shows: [TVShow]) -> [Movie] {
         shows.map { Movie(id: $0.id, title: $0.name, overview: $0.overview, posterPath: $0.posterPath, releaseDate: $0.firstAirDate, voteAverage: $0.voteAverage) }
     }
-
-    private func asMovies(_ shows: [TVShow]) -> [Movie] {
-        shows.map { Movie(id: $0.id, title: $0.name, overview: $0.overview, posterPath: $0.posterPath, releaseDate: $0.firstAirDate, voteAverage: $0.voteAverage) }
-    }
     
     public func movieDetails(id: Int, language: String = "en") async throws -> MovieDetails {
         async let movie: Movie = request(endpoint: "movie/\(id)", queryItems: [URLQueryItem(name: "language", value: language)], type: Movie.self)
@@ -448,6 +444,38 @@ public class TMDBClient {
             URLQueryItem(name: "language", value: language),
             URLQueryItem(name: "with_watch_providers", value: String(provider.rawValue)),
             URLQueryItem(name: "watch_region", value: region),
+            URLQueryItem(name: "sort_by", value: "popularity.desc"),
+            URLQueryItem(name: "page", value: String(page))
+        ]
+        let response: SearchResponse<Movie> = try await request(endpoint: "discover/movie", queryItems: query, type: SearchResponse<Movie>.self)
+        return response.results
+    }
+
+    /// Returns trending TV shows for a specific genre using ``discover`` sorted by popularity.
+    /// - Parameters:
+    ///   - genre: The genre identifier as returned by ``GenreInfo``.
+    ///   - language: Optional language for the results. Defaults to English.
+    ///   - page: Page number for infinite scrolling support.
+    public func trendingTVShows(genre: Int, language: String = "en", page: Int = 1) async throws -> [TVShow] {
+        let query: [URLQueryItem] = [
+            URLQueryItem(name: "language", value: language),
+            URLQueryItem(name: "with_genres", value: String(genre)),
+            URLQueryItem(name: "sort_by", value: "popularity.desc"),
+            URLQueryItem(name: "page", value: String(page))
+        ]
+        let response: SearchResponse<TVShow> = try await request(endpoint: "discover/tv", queryItems: query, type: SearchResponse<TVShow>.self)
+        return response.results
+    }
+
+    /// Returns trending movies for a specific genre using ``discover`` sorted by popularity.
+    /// - Parameters:
+    ///   - genre: The genre identifier as returned by ``GenreInfo``.
+    ///   - language: Optional language for the results. Defaults to English.
+    ///   - page: Page number for infinite scrolling support.
+    public func trendingMovies(genre: Int, language: String = "en", page: Int = 1) async throws -> [Movie] {
+        let query: [URLQueryItem] = [
+            URLQueryItem(name: "language", value: language),
+            URLQueryItem(name: "with_genres", value: String(genre)),
             URLQueryItem(name: "sort_by", value: "popularity.desc"),
             URLQueryItem(name: "page", value: String(page))
         ]
@@ -664,40 +692,5 @@ public class TMDBClient {
         return categories
     }
 
-    /// Convenience method returning a set of common TV show categories.
-    public func defaultTVShowCategories(region: String = "US", language: String = "en") -> [MovieCategory] {
-        [
-            MovieCategory(name: "Trending") { page in
-                try await self.trendingTVShows(language: language, page: page)
-            },
-            MovieCategory(name: "Top Rated") { page in
-                let shows = try await self.topRatedTVShows(language: language, page: page)
-                return self.asMovies(shows)
-            },
-            MovieCategory(name: "Popular") { page in
-                let shows = try await self.popularTVShows(language: language, page: page)
-                return self.asMovies(shows)
-            },
-            MovieCategory(name: "Top on Netflix") { page in
-                let shows = try await self.topTVShows(provider: .netflix, region: region, language: language, page: page)
-                return self.asMovies(shows)
-            },
-            MovieCategory(name: "Top on Prime Video") { page in
-                let shows = try await self.topTVShows(provider: .primeVideo, region: region, language: language, page: page)
-                return self.asMovies(shows)
-            }
-        ]
-    }
-
-    /// Returns default TV show categories and optionally preloads the first page of each one.
-    public func defaultTVShowCategories(region: String = "US", language: String = "en", preload: Bool) async throws -> [MovieCategory] {
-        let categories = defaultTVShowCategories(region: region, language: language)
-        if preload {
-            for category in categories {
-                try await category.reload()
-            }
-        }
-        return categories
-    }
 }
 

--- a/YoddWatchLibrary/YoddWatchLibrary.docc/YoddWatchLibrary.md
+++ b/YoddWatchLibrary/YoddWatchLibrary.docc/YoddWatchLibrary.md
@@ -36,6 +36,8 @@ A lightweight framework providing access to The Movie Database API and basic use
 - ``GenreInfo``
 - ``ImageInfo``
 - ``VideoInfo``
+- ``TMDBClient.trendingMovies(genre:language:page:)``
+- ``TMDBClient.trendingTVShows(genre:language:page:)``
 - ``MovieCategory``
 - ``TVShowCategory``
 - ``TMDBClient.defaultMovieCategories(region:language:)``


### PR DESCRIPTION
## Summary
- remove duplicate `defaultTVShowCategories` functions
- add helpers for trending movies and TV shows by genre
- document new genre-based helpers
- clarify docs for new functions

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68850595ed7483218dc3fd287a992cba