### PR TITLE
Add TMDB logo images

### DIFF
--- a/YoddWatchLibrary/TMDBClient.swift
+++ b/YoddWatchLibrary/TMDBClient.swift
@@ -125,6 +125,7 @@ public struct VideoInfo: Codable {
 public struct MediaImages: Codable {
     public let posters: [ImageInfo]
     public let backdrops: [ImageInfo]
+    public let logos: [ImageInfo]
 }
 
 public struct PersonImages: Codable {
@@ -277,6 +278,7 @@ struct TrendingResponse<T: Codable>: Codable {
 struct ImagesResponse: Codable {
     let backdrops: [ImageInfo]
     let posters: [ImageInfo]
+    let logos: [ImageInfo]?
 }
 
 struct PersonImagesResponse: Codable {
@@ -526,12 +528,12 @@ public class TMDBClient {
 
     public func movieImages(id: Int) async throws -> MediaImages {
         let resp: ImagesResponse = try await request(endpoint: "movie/\(id)/images", type: ImagesResponse.self)
-        return MediaImages(posters: resp.posters, backdrops: resp.backdrops)
+        return MediaImages(posters: resp.posters, backdrops: resp.backdrops, logos: resp.logos ?? [])
     }
 
     public func tvShowImages(id: Int) async throws -> MediaImages {
         let resp: ImagesResponse = try await request(endpoint: "tv/\(id)/images", type: ImagesResponse.self)
-        return MediaImages(posters: resp.posters, backdrops: resp.backdrops)
+        return MediaImages(posters: resp.posters, backdrops: resp.backdrops, logos: resp.logos ?? [])
     }
 
     public func personImages(id: Int) async throws -> [ImageInfo] {

--- a/YoddWatchLibrary/YoddWatchLibrary.docc/YoddWatchLibrary.md
+++ b/YoddWatchLibrary/YoddWatchLibrary.docc/YoddWatchLibrary.md
@@ -9,7 +9,7 @@ A lightweight framework providing access to The Movie Database API and basic use
 `UserPreferences` allows storing favorites, watched items, the preferred language (`en` or `it`), custom lists and playback progress.
 
 `Movie` and `TVShow` expose additional optional details when fetching single items, such as backdrops, taglines, runtimes and genres.
-`Person` now includes optional biography, birthday and place of birth when requesting individual cast members. The client also exposes endpoints to retrieve trailers and additional images for movies, TV shows and people.
+`Person` now includes optional biography, birthday and place of birth when requesting individual cast members. The client also exposes endpoints to retrieve trailers and additional images for movies, TV shows and people. `MediaImages` includes logos in addition to posters and backdrops.
 
 
 ## Topics
@@ -35,6 +35,7 @@ A lightweight framework providing access to The Movie Database API and basic use
 - ``Genre``
 - ``GenreInfo``
 - ``ImageInfo``
+- ``MediaImages``
 - ``VideoInfo``
 - ``TMDBClient.trendingMovies(genre:language:page:)``
 - ``TMDBClient.trendingTVShows(genre:language:page:)``

--- a/YoddWatchLibraryTests/YoddWatchLibraryTests.swift
+++ b/YoddWatchLibraryTests/YoddWatchLibraryTests.swift
@@ -137,4 +137,20 @@ struct YoddWatchLibraryTests {
         #expect(person.placeOfBirth == "Somewhere")
     }
 
+    @Test func decodeMediaImages() throws {
+        let json = """
+        {
+            "posters": [{"file_path": "/p.jpg", "width": 500, "height": 750}],
+            "backdrops": [{"file_path": "/b.jpg", "width": 1280, "height": 720}],
+            "logos": [{"file_path": "/l.png", "width": 200, "height": 100}]
+        }
+        """.data(using: .utf8)!
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let images = try decoder.decode(MediaImages.self, from: json)
+        #expect(images.logos.first?.filePath == "/l.png")
+        #expect(images.posters.count == 1)
+        #expect(images.backdrops.count == 1)
+    }
+
 }


### PR DESCRIPTION
## Summary
- add `logos` field to `MediaImages` and `ImagesResponse`
- return logos when fetching movie and TV show images
- mention logos in documentation
- test decoding of new `MediaImages` field

## Testing
- `swift test --enable-test-discovery`

------
https://chatgpt.com/codex/tasks/task_e_6887ebd282dc832185501680eed654fe