### PR TITLE
Enhance TMDB fetchers with more metadata

### DIFF
--- a/YoddWatchLibrary/TMDBClient.swift
+++ b/YoddWatchLibrary/TMDBClient.swift
@@ -29,8 +29,12 @@ public struct Movie: Codable {
     public let tagline: String?
     public let homepage: String?
     public let genres: [GenreInfo]?
+    public let status: String?
+    public let budget: Int?
+    public let revenue: Int?
+    public let imdbId: String?
 
-    public init(id: Int, title: String, overview: String?, posterPath: String?, backdropPath: String? = nil, releaseDate: String?, voteAverage: Double?, runtime: Int? = nil, tagline: String? = nil, homepage: String? = nil, genres: [GenreInfo]? = nil) {
+    public init(id: Int, title: String, overview: String?, posterPath: String?, backdropPath: String? = nil, releaseDate: String?, voteAverage: Double?, runtime: Int? = nil, tagline: String? = nil, homepage: String? = nil, genres: [GenreInfo]? = nil, status: String? = nil, budget: Int? = nil, revenue: Int? = nil, imdbId: String? = nil) {
         self.id = id
         self.title = title
         self.overview = overview
@@ -42,10 +46,14 @@ public struct Movie: Codable {
         self.tagline = tagline
         self.homepage = homepage
         self.genres = genres
+        self.status = status
+        self.budget = budget
+        self.revenue = revenue
+        self.imdbId = imdbId
     }
 
     public init(id: Int, title: String, overview: String?, posterPath: String?, releaseDate: String?, voteAverage: Double?) {
-        self.init(id: id, title: title, overview: overview, posterPath: posterPath, backdropPath: nil, releaseDate: releaseDate, voteAverage: voteAverage, runtime: nil, tagline: nil, homepage: nil, genres: nil)
+        self.init(id: id, title: title, overview: overview, posterPath: posterPath, backdropPath: nil, releaseDate: releaseDate, voteAverage: voteAverage, runtime: nil, tagline: nil, homepage: nil, genres: nil, status: nil, budget: nil, revenue: nil, imdbId: nil)
     }
 }
 
@@ -63,8 +71,11 @@ public struct TVShow: Codable {
     public let numberOfSeasons: Int?
     public let numberOfEpisodes: Int?
     public let episodeRunTime: [Int]?
+    public let status: String?
+    public let inProduction: Bool?
+    public let originCountry: [String]?
 
-    public init(id: Int, name: String, overview: String?, posterPath: String?, backdropPath: String? = nil, firstAirDate: String?, voteAverage: Double?, tagline: String? = nil, homepage: String? = nil, genres: [GenreInfo]? = nil, numberOfSeasons: Int? = nil, numberOfEpisodes: Int? = nil, episodeRunTime: [Int]? = nil) {
+    public init(id: Int, name: String, overview: String?, posterPath: String?, backdropPath: String? = nil, firstAirDate: String?, voteAverage: Double?, tagline: String? = nil, homepage: String? = nil, genres: [GenreInfo]? = nil, numberOfSeasons: Int? = nil, numberOfEpisodes: Int? = nil, episodeRunTime: [Int]? = nil, status: String? = nil, inProduction: Bool? = nil, originCountry: [String]? = nil) {
         self.id = id
         self.name = name
         self.overview = overview
@@ -78,10 +89,13 @@ public struct TVShow: Codable {
         self.numberOfSeasons = numberOfSeasons
         self.numberOfEpisodes = numberOfEpisodes
         self.episodeRunTime = episodeRunTime
+        self.status = status
+        self.inProduction = inProduction
+        self.originCountry = originCountry
     }
 
     public init(id: Int, name: String, overview: String?, posterPath: String?, firstAirDate: String?, voteAverage: Double?) {
-        self.init(id: id, name: name, overview: overview, posterPath: posterPath, backdropPath: nil, firstAirDate: firstAirDate, voteAverage: voteAverage, tagline: nil, homepage: nil, genres: nil, numberOfSeasons: nil, numberOfEpisodes: nil, episodeRunTime: nil)
+        self.init(id: id, name: name, overview: overview, posterPath: posterPath, backdropPath: nil, firstAirDate: firstAirDate, voteAverage: voteAverage, tagline: nil, homepage: nil, genres: nil, numberOfSeasons: nil, numberOfEpisodes: nil, episodeRunTime: nil, status: nil, inProduction: nil, originCountry: nil)
     }
 }
 
@@ -113,6 +127,8 @@ public struct ImageInfo: Codable {
     public let filePath: String
     public let width: Int?
     public let height: Int?
+    public let iso6391: String?
+    public let aspectRatio: Double?
 }
 
 public struct VideoInfo: Codable {
@@ -120,6 +136,10 @@ public struct VideoInfo: Codable {
     public let key: String
     public let site: String
     public let type: String
+    public let size: Int?
+    public let official: Bool?
+    public let publishedAt: String?
+    public let id: String?
 }
 
 public struct MediaImages: Codable {
@@ -526,13 +546,19 @@ public class TMDBClient {
         imageBaseURL.appendingPathComponent(size).appendingPathComponent(path)
     }
 
-    public func movieImages(id: Int) async throws -> MediaImages {
-        let resp: ImagesResponse = try await request(endpoint: "movie/\(id)/images", type: ImagesResponse.self)
+    public func movieImages(id: Int, language: String = "en") async throws -> MediaImages {
+        let resp: ImagesResponse = try await request(
+            endpoint: "movie/\(id)/images",
+            queryItems: [URLQueryItem(name: "include_image_language", value: "\(language),null")],
+            type: ImagesResponse.self)
         return MediaImages(posters: resp.posters, backdrops: resp.backdrops, logos: resp.logos ?? [])
     }
 
-    public func tvShowImages(id: Int) async throws -> MediaImages {
-        let resp: ImagesResponse = try await request(endpoint: "tv/\(id)/images", type: ImagesResponse.self)
+    public func tvShowImages(id: Int, language: String = "en") async throws -> MediaImages {
+        let resp: ImagesResponse = try await request(
+            endpoint: "tv/\(id)/images",
+            queryItems: [URLQueryItem(name: "include_image_language", value: "\(language),null")],
+            type: ImagesResponse.self)
         return MediaImages(posters: resp.posters, backdrops: resp.backdrops, logos: resp.logos ?? [])
     }
 

--- a/YoddWatchLibrary/YoddWatchLibrary.docc/YoddWatchLibrary.md
+++ b/YoddWatchLibrary/YoddWatchLibrary.docc/YoddWatchLibrary.md
@@ -24,8 +24,8 @@ A lightweight framework providing access to The Movie Database API and basic use
 - ``Episode``
 - ``TMDBClient.episodes(showId:season:language:)``
 - ``TMDBClient.numberOfSeasons(showId:language:)``
-- ``TMDBClient.movieImages(id:)``
-- ``TMDBClient.tvShowImages(id:)``
+ - ``TMDBClient.movieImages(id:language:)``
+ - ``TMDBClient.tvShowImages(id:language:)``
 - ``TMDBClient.personImages(id:)``
 - ``TMDBClient.movieTrailerURL(id:language:)``
 - ``TMDBClient.tvShowTrailerURL(id:language:)``

--- a/YoddWatchLibraryTests/YoddWatchLibraryTests.swift
+++ b/YoddWatchLibraryTests/YoddWatchLibraryTests.swift
@@ -93,7 +93,11 @@ struct YoddWatchLibraryTests {
             "runtime": 120,
             "tagline": "Tag",
             "homepage": "https://example.com",
-            "genres": [{"id": 1, "name": "Drama"}]
+            "genres": [{"id": 1, "name": "Drama"}],
+            "status": "Released",
+            "budget": 1000000,
+            "revenue": 5000000,
+            "imdb_id": "tt1234567"
         }
         """.data(using: .utf8)!
         let decoder = JSONDecoder()
@@ -102,6 +106,9 @@ struct YoddWatchLibraryTests {
         #expect(movie.id == 10)
         #expect(movie.runtime == 120)
         #expect(movie.genres?.first?.name == "Drama")
+        #expect(movie.status == "Released")
+        #expect(movie.budget == 1000000)
+        #expect(movie.imdbId == "tt1234567")
     }
 
     @Test func decodeVideoInfo() throws {
@@ -110,11 +117,18 @@ struct YoddWatchLibraryTests {
             "name": "Trailer",
             "key": "abc",
             "site": "YouTube",
-            "type": "Trailer"
+            "type": "Trailer",
+            "size": 1080,
+            "official": true,
+            "published_at": "2024-01-01",
+            "id": "v1"
         }
         """.data(using: .utf8)!
         let video = try JSONDecoder().decode(VideoInfo.self, from: json)
         #expect(video.key == "abc")
+        #expect(video.size == 1080)
+        #expect(video.official == true)
+        #expect(video.id == "v1")
     }
 
     @Test func decodePersonDetails() throws {
@@ -140,15 +154,16 @@ struct YoddWatchLibraryTests {
     @Test func decodeMediaImages() throws {
         let json = """
         {
-            "posters": [{"file_path": "/p.jpg", "width": 500, "height": 750}],
-            "backdrops": [{"file_path": "/b.jpg", "width": 1280, "height": 720}],
-            "logos": [{"file_path": "/l.png", "width": 200, "height": 100}]
+            "posters": [{"file_path": "/p.jpg", "width": 500, "height": 750, "iso_639_1": "en", "aspect_ratio": 0.7}],
+            "backdrops": [{"file_path": "/b.jpg", "width": 1280, "height": 720, "iso_639_1": "en", "aspect_ratio": 1.77}],
+            "logos": [{"file_path": "/l.png", "width": 200, "height": 100, "iso_639_1": "en", "aspect_ratio": 2.0}]
         }
         """.data(using: .utf8)!
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         let images = try decoder.decode(MediaImages.self, from: json)
         #expect(images.logos.first?.filePath == "/l.png")
+        #expect(images.logos.first?.iso6391 == "en")
         #expect(images.posters.count == 1)
         #expect(images.backdrops.count == 1)
     }


### PR DESCRIPTION
## Summary
- add status, budget, revenue and imdb ID to `Movie`
- add status, inProduction and originCountry to `TVShow`
- expose language and aspect ratio info in `ImageInfo`
- include more fields in `VideoInfo`
- filter image results by language for movie/TV show images
- document updated APIs
- update unit tests for new fields

## Testing
- `swift test -q`

------
https://chatgpt.com/codex/tasks/task_e_6887f6dce88483219f6f069a63d3b787